### PR TITLE
Update task that looks for existing packages

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -12,11 +12,12 @@
   tags:
     - archlinux_aur_deps
 
-- name: Check if yaourt is installed
+- name: Check if packages to be installed are already installed
   shell: pacman -Q {{ item }}
   register: archlinux_aur_check_result
   with_items: "{{ archlinux_aur_pkgs }}"
   changed_when: false
+  check_mode: false
   failed_when: false
   tags:
     - archlinux_aur_check


### PR DESCRIPTION
A task in `tasks/main.yml` is described as checking whether yaourt is
installed. This description is incorrect. The task actually checks to
see whether a user-supplied list of packages is installed. Fix this
error.

Let this task always run in normal mode, even when check mode is
enabled. It's safe for this task to do so, as this task's purpose is to
gather information, not to change the state of the target system. This
make this role behave better when check mode is enabled, as the variable
created by this task (`archlinux_aur_check_result`) will now be created.
Plus, the ansible-lint tool is happier with the result.