### PR TITLE
Declare language of code samples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ansible role which installs Arch Linux packages from AUR.
 Examples
 --------
 
-```
+```yaml
 ---
 
 - name: Install Yaourt
@@ -26,7 +26,7 @@ Role variables
 
 Variables used by the role is as follows:
 
-```
+```yaml
 # Packages to be installed
 archlinux_aur_pkgs: []
 


### PR DESCRIPTION
Markdown code fences can be annotated with the language of the code
contained therein. This annotation is recognized by at least the
CommonMark standard and GitHub's implementation of markdown.